### PR TITLE
Refactor: Update resume content and add basic i18n structure

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,16 +33,8 @@ about_content: | # this will include new lines to allow paragraphs
 # experience_title: Experience
 
 # Education Section
-# educaton_title: Education
+educaton_title: Education
 
-# More Section
-# more_title: A Little More About Me
-more_content: | # this will include new lines to allow paragraphs
-  Alongside my interests in networks and software engineering some of my other interests and hobbies are:
-   - Home training
-   - Gaming
-   - Cook
- 
 # Footer
 footer_show_references: true
 

--- a/_data/education.yml
+++ b/_data/education.yml
@@ -1,13 +1,28 @@
 - layout: left
   name: Sogang University
+  dates: 2020 - 2022
+  qualification: 컴퓨터 과학 석사
+  quote: "AI 및 고급 컴퓨팅에 중점을 둔 석사 학위."
+  description: |
+    Courses taken during the Master's program:
+    - Data mining
+    - 수치 컴퓨팅 및 gpu 프로그래밍 (Numerical Computing and GPU Programming)
+    - 동영상 해석 (Video Analysis)
+    - 신경회로망 (Neural Networks)
+    - 멀티미디어 특론 (Special Topics in Multimedia)
+    - 고급 알고리즘 (Advanced Algorithms)
+    - 임베디드 컴퓨터 구조 (Embedded Computer Architecture)
+
+- layout: left
+  name: 서강대학교
   dates: 2014 - 2020
-  qualification: BSc Computer Science
+  qualification: 컴퓨터 과학 학사
   quote: >
-    Established in 1969, "Be as proud of Sogang as Sogang is proud of you."
+    1969년 설립, "그대 서강의 자랑이듯, 서강 그대의 자랑이어라."
     
   description: | # this will include new lines to allow paragraphs
-    During my time at Sogang I learnt most of my key skills that have I have taken through my career such as teamwork and working to tight deadlines. I thouroughly enjoyed my time as university and learnt a lot about a healthy work life balance.
+    서강대학교 재학 중 팀워크, 마감 기한 준수 등 중요한 역량을 배웠습니다. 대학 생활을 통해 일과 삶의 균형에 대해 많이 배웠습니다.
     <br>
-    Course: Data Structure, Algorithm Design and Analysis, Programming Language, Operating System, Internet Programming, Advanced Software Practice etc..
+    주요 과목: 자료구조, 알고리즘 설계와 분석, 프로그래밍 언어, 운영체제, 인터넷 프로그래밍, 고급 소프트웨어 실습 등.
 
    

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0; url=index_en.html">
+<title>Page Redirection</title>
+</head>
+<body>
+<p>If you are not redirected automatically, follow this <a href="index_en.html">link to the page</a>.</p>
+</body>
+</html>

--- a/index_en.md
+++ b/index_en.md
@@ -7,3 +7,4 @@
 #
 layout: default
 ---
+<a href="index_ko.html">한국어</a>

--- a/index_ko.md
+++ b/index_ko.md
@@ -1,0 +1,10 @@
+---
+#
+# By default, content added below the "---" mark will appear in the home page
+# between the top bar and the list of recent posts.
+# To change the home page layout, edit the _layouts/home.html file.
+# See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+#
+layout: default
+---
+<a href="index_en.html">English</a>


### PR DESCRIPTION
- Removed "A Little More About Me" section.
- Added Master's degree to Education section with specified courses.
- Set up English as the default landing page (`index_en.html`).
- Added a Korean version (`index_ko.html`) with a language switcher.
- Translated all content within the Education section to Korean. Due to theme structure, this section will appear in Korean on both English and Korean pages.
- General site information (name, title, about me) remains in English on both versions.
- Root `index.html` now redirects to `index_en.html`.