### PR TITLE
Feat: Add language switch link to about_content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ linkedin_username: youngjoonhwang-47aa38161
 # about_title: About Me
 about_profile_image: images/profile.jpg
 about_content: | # this will include new lines to allow paragraphs
-  AI Consultant Expert with a Master's degree from Sogang University, specializing in leveraging AI to solve complex business challenges. Proven experience in developing and implementing innovative AI solutions.
+  AI Consultant Expert with a Master's degree from Sogang University, specializing in leveraging AI to solve complex business challenges. Proven experience in developing and implementing innovative AI solutions. <a href="index_ko.html">(Switch to Korean)</a>
 
 # Projects Section
 # projects_title: Projects


### PR DESCRIPTION
- I've appended a link to the Korean version (index_ko.html) within the about_content in _config.yml.
- This is an attempt to make the language switch option available if direct HTML injection into page templates is not supported by the theme for displaying a separate button.